### PR TITLE
Remove dependency on sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ script:
   - sphinx-build -M doctest docs docs/_build
   - sphinx-build -M linkcheck docs docs/_build
   - sphinx-build -M coverage docs docs/_build
-  - python setup.py build_sphinx -b html,man
+  - sphinx-build -M html docs docs/_build
+  - sphinx-build -M man docs docs/_build
 
 deploy:
   provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from sphinx.setup_command import BuildDoc
 from setuptools import setup, find_packages
 
 setup(
@@ -11,7 +10,6 @@ setup(
     entry_points={
         "console_scripts": ["ebuildtester = ebuildtester.main:main"]
     },
-    cmdclass={'build_sphinx': BuildDoc},
     author="Nicolas Bock",
     author_email="nicolasbock@gmail.com",
     description="A dockerized approach to test a Gentoo package within a clean stage3",


### PR DESCRIPTION
By using sphinx in `setup.py` we introduced a dependency on sphinx for merely building the project. This change removes that dependency.