### PR TITLE
Add `--unstable` option

### DIFF
--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -169,6 +169,9 @@ class Docker:
                      ">> /etc/portage/make.conf")
         self.execute(("echo MAKEOPTS=\\\"-j%d\\\" " % (options.options.threads)) +
                      ">> /etc/portage/make.conf")
+        if options.options.unstable:
+            self.execute("echo ACCEPT_KEYWORDS=\\\"~amd64\\\" " +
+                         ">> /etc/portage/make.conf")
 
     def _enable_overlays(self, overlays):
         """Enable overlays."""
@@ -203,8 +206,12 @@ class Docker:
         if options.options.atom is not None:
             options.log.info("unmasking %s" % options.options.atom)
             for a in options.options.atom:
+                if options.options.live_ebuild:
+                    unmask_keyword = "**"
+                else:
+                    unmask_keyword = "~amd64"
                 self.execute(
-                    "echo \"" + str(a) + "\" ~amd64 >> " +
+                    "echo \"" + str(a) + "\" " + unmask_keyword + " >> " +
                     "/etc/portage/package.accept_keywords")
             if len(options.options.use) > 0:
                 for a in options.options.atom:

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -21,6 +21,10 @@ def parse_commandline(args):
         nargs="+",
         action="append")
     parser.add_argument(
+        "--live-ebuild",
+        help="Unmask the live ebuild of the atom",
+        action="store_true")
+    parser.add_argument(
         "--manual",
         help="Install package manually",
         default=False,
@@ -51,11 +55,20 @@ def parse_commandline(args):
         default=[],
         nargs="+")
     parser.add_argument(
+        "--global-use",
+        help="Set global USE flag",
+        default=[],
+        nargs="+")
+    parser.add_argument(
         "--unmask",
         metavar="ATOM",
         help="Unmask atom (can be used multiple times)",
         default=[],
         action="append")
+    parser.add_argument(
+        "--unstable",
+        help="Globally 'unstable' system, i.e. ~amd64",
+        action="store_true")
     parser.add_argument(
         "--gcc-version",
         metavar="VER",


### PR DESCRIPTION
This change adds an `--unstable` option which installs in an unstable
system (global ~amd64), and a `--live-ebuild` option to indicate that
the atom(s) are live ebuilds.