### PR TITLE
Intercept keyboard interrupts (CTRL-C)

### DIFF
--- a/ebuildtester/main.py
+++ b/ebuildtester/main.py
@@ -27,6 +27,7 @@ def main():
         container.execute("echo emerge --ask --autounmask-write=y --verbose " +
                           " ".join(map(str, options.options.atom)) +
                           " >> ~/.bash_history")
+
         for i in range(5):
             options.log.info("emerge attempt %d (of %d)" % (i + 1, 5))
             try:
@@ -41,5 +42,4 @@ def main():
         options.log.info("opening interactive shell")
         container.shell()
 
-    if options.options.rm:
-        container.remove()
+        container.cleanup()


### PR DESCRIPTION
On C-c enter a shell and then initiate shutdown when that shell is exited. This behavior seems to make more sense than to kill the driving process in effect losing control over the docker container.