### PR TITLE
ebuildtester/docker.py: fix directory issue

### DIFF
--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -266,8 +266,8 @@ class Docker:
             options.log.info("  unmasking %s" % a)
             self.execute("mkdir -p /etc/portage/package.accept_keywords")
             self.execute(
-                "echo \"%s\" ~amd64 >> /etc/portage/package.accept_keywords" %
-                a)
+                "echo \"%s\" ~amd64 >> "
+                "/etc/portage/package.accept_keywords/testbuild" % a)
 
     def _update(self):
         """Update container."""
@@ -304,7 +304,7 @@ class Docker:
             self.execute(
                 ("echo =sys-devel/gcc-%s ** >> " %
                  options.options.gcc_version) +
-                "/etc/portage/package.accept_keywords")
+                "/etc/portage/package.accept_keywords/testbuild")
             self.execute("emerge --verbose sys-devel/gcc")
             gcc = re.sub("-r[0-9]+$", "", options.options.gcc_version)
             self.execute("gcc-config $(gcc-config --list-profiles | " +


### PR DESCRIPTION
_unmask tries to write it's changes to /etc/portage/package.accept_keywords
but created it as a directory before. This patch fixes this, by writing
out to /etc/portage/package.accept_keywords/testbuild like it's done in
_unmask_atom

See this output from a run (third to last line):
```
2018-10-08 13:32:20,719 - unmasking [Atom("=media-gfx/alembic-1.7.9")]
2018-10-08 13:32:20,720 - dfbc5d mkdir -p /etc/portage/package.accept_keywords
2018-10-08 13:32:20,918 - dfbc5d echo "=media-gfx/alembic-1.7.9" ~amd64 >> /etc/portage/package.accept_keywords/testbuild
2018-10-08 13:32:21,120 - dfbc5d echo =media-gfx/alembic-1.7.9 boost python zlib >> /etc/portage/package.use/testbuild
2018-10-08 13:32:21,320 - unmasking additional atoms
2018-10-08 13:32:21,320 -   unmasking =media-gfx/alembix-1.7.9
2018-10-08 13:32:21,321 - dfbc5d mkdir -p /etc/portage/package.accept_keywords
2018-10-08 13:32:21,552 - dfbc5d echo "=media-gfx/alembix-1.7.9" ~amd64 >> /etc/portage/package.accept_keywords
2018-10-08 13:32:21,682 - dfbc5d (stderr): /bin/bash: line 1: /etc/portage/package.accept_keywords: Is a directory
2018-10-08 13:32:21,745 - running in container dfbc5d355093f86df080bcf4b0c331ddf6eb0f3f5ce373094e5a40e21594eb67
```
