### PR TITLE
removing unsuported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3{3,4,5,6},bandit,pep8
+envlist = py3{6,7,8},bandit,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
First of all thanks for a great and useful tool. I have created small clean up pr for it.

1. Removed support of python 2.7, 3.3, 3.4 since they are deprecated(https://pythonclock.org/ and https://devguide.python.org/#status-of-python-branches)
2. Added travis runs of Python 3.7 and 3.8

Also, can you please release new version, so it can be updated in portage tree?