### PR TITLE
Fix deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ deploy:
   skip_cleanup: false
   on:
     tags: true
+    python: "3.6"
     branch: master

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Deploy only for one Python env. If we don't restrict here then Travis
will try to upload to PyPi multiple times (once for each Python env)
and will fail.

This change creates a universal `bdist_wheel`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>