### PR TITLE
Make the installation of basic packages optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,40 +70,43 @@ The command understands the following command line arguments:
 
 .. code-block:: bash
 
-        usage: ebuildtester [-h] [--version] [--atom ATOM [ATOM ...]] [--live-ebuild] [--manual]
-                            --portage-dir PORTAGE_DIR [--overlay-dir OVERLAY_DIR] [--update]
-                            [--threads N] [--use USE [USE ...]]
-                            [--global-use GLOBAL_USE [GLOBAL_USE ...]] [--unmask ATOM] [--unstable]
-                            [--gcc-version VER] [--rm] [--pull]
-                            [--storage-opt STORAGE_OPT [STORAGE_OPT ...]] [--with-X] [--with-vnc]
-                            [--profile {default/linux/amd64/17.1,default/linux/amd64/17.1/systemd}]
+    usage: ebuildtester [-h] [--version] [--atom ATOM [ATOM ...]] [--live-ebuild] [--manual] --portage-dir PORTAGE_DIR [--overlay-dir OVERLAY_DIR] [--update] [--install-basic-packages] [--threads N]
+                        [--use USE [USE ...]] [--global-use GLOBAL_USE [GLOBAL_USE ...]] [--unmask ATOM] [--unstable] [--gcc-version VER] [--python-single-target PYTHON_SINGLE_TARGET]
+                        [--python-targets PYTHON_TARGETS] [--rm] [--pull] [--storage-opt STORAGE_OPT [STORAGE_OPT ...]] [--with-X] [--with-vnc]
+                        [--profile {default/linux/amd64/17.1,default/linux/amd64/17.1/systemd}]
 
-        A dockerized approach to test a Gentoo package within a clean stage3.
+    A dockerized approach to test a Gentoo package within a clean stage3.
 
-        optional arguments:
-          -h, --help            show this help message and exit
-          --version             show program's version number and exit
-          --atom ATOM [ATOM ...]
-                                The package atom(s) to install
-          --live-ebuild         Unmask the live ebuild of the atom
-          --manual              Install package manually
-          --portage-dir PORTAGE_DIR
-                                The local portage directory
-          --overlay-dir OVERLAY_DIR
-                                Add overlay dir (can be used multiple times)
-          --update              Update container before installing atom
-          --threads N           Use N (default 8) threads to build packages
-          --use USE [USE ...]   The use flags for the atom
-          --global-use GLOBAL_USE [GLOBAL_USE ...]
-                                Set global USE flag
-          --unmask ATOM         Unmask atom (can be used multiple times)
-          --unstable            Globally 'unstable' system, i.e. ~amd64
-          --gcc-version VER     Use gcc version VER
-          --rm                  Remove container after session is done
-          --pull                Download latest 'gentoo/stage3-amd64' docker image
-          --storage-opt STORAGE_OPT [STORAGE_OPT ...]
-                                Storage driver options for all volumes (same as Docker param)
-          --with-X              Globally enable the X USE flag
-          --with-vnc            Install VNC server to test graphical applications
-          --profile {default/linux/amd64/17.1,default/linux/amd64/17.1/systemd}
-                                The profile to use
+    optional arguments:
+      -h, --help            show this help message and exit
+      --version             show program's version number and exit
+      --atom ATOM [ATOM ...]
+                            The package atom(s) to install
+      --live-ebuild         Unmask the live ebuild of the atom
+      --manual              Install package manually
+      --portage-dir PORTAGE_DIR
+                            The local portage directory
+      --overlay-dir OVERLAY_DIR
+                            Add overlay dir (can be used multiple times)
+      --update              Update container before installing atom
+      --install-basic-packages
+                            Install basic packages after container starts
+      --threads N           Use N (default 8) threads to build packages
+      --use USE [USE ...]   The use flags for the atom
+      --global-use GLOBAL_USE [GLOBAL_USE ...]
+                            Set global USE flag
+      --unmask ATOM         Unmask atom (can be used multiple times)
+      --unstable            Globally 'unstable' system, i.e. ~amd64
+      --gcc-version VER     Use gcc version VER
+      --python-single-target PYTHON_SINGLE_TARGET
+                            Specify a PYTHON_SINGLE_TARGET
+      --python-targets PYTHON_TARGETS
+                            Specify a PYTHON_TARGETS
+      --rm                  Remove container after session is done
+      --pull                Download latest 'gentoo/stage3-amd64' docker image
+      --storage-opt STORAGE_OPT [STORAGE_OPT ...]
+                            Storage driver options for all volumes (same as Docker param)
+      --with-X              Globally enable the X USE flag
+      --with-vnc            Install VNC server to test graphical applications
+      --profile {default/linux/amd64/17.1,default/linux/amd64/17.1/systemd}
+                            The profile to use

--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -298,10 +298,13 @@ class Docker:
     def _install_basics(self):
         """Install some basic packages."""
 
-        options.log.info("installing basic packages: %s" %
-                         options.base_packages)
-        self.execute("emerge --verbose %s" %
-                     " ".join(map(str, options.base_packages)))
+        if not options.options.install_basic_packages:
+            options.log.info("skipping basic packages")
+        else:
+            options.log.info("installing basic packages: %s" %
+                             options.base_packages)
+            self.execute("emerge --verbose %s" %
+                         " ".join(map(str, options.base_packages)))
 
     def _enable_global_use(self):
         """Enable global USE settings."""

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -42,6 +42,10 @@ def parse_commandline(args):
         help="Update container before installing atom",
         action="store_true")
     parser.add_argument(
+        "--install-basic-packages",
+        help="Install basic packages after container starts",
+        action="store_true")
+    parser.add_argument(
         "--threads",
         metavar="N",
         help="Use N (default %(default)s) threads to build packages",


### PR DESCRIPTION
This change adds a command line option that makes the installation of
the basic packages optional. Note that this change alters the current
behavior of the program in that it does not install those packages
anymore unless told.

Closes: nicolasbock/ebuildtester#130

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>