### PR TITLE
Do not restrict profile argument

### DIFF
--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -110,8 +110,6 @@ def parse_commandline(args):
     parser.add_argument(
         "--profile",
         help="The profile to use (default = %(default)s)",
-        choices=["default/linux/amd64/17.1",
-                 "default/linux/amd64/17.1/systemd"],
         default="default/linux/amd64/17.1")
     parser.add_argument(
         "--docker-image",


### PR DESCRIPTION
There are many correct choices for the profile argument. Restricting
the argument for the `--profile` argument in the parser is challenging
to maintain since it might consist of a product of profiles and
architectures.

This change removes any restriction on `--profile`. Note that this
means that a non-existing choice will fail in the container and might
be harder to debug.

Fixes: nicolasbock/ebuildtester#152
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>