### PR TITLE
Update default docker image

### DIFF
--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -91,10 +91,6 @@ def parse_commandline(args):
         help="Remove container after session is done",
         action="store_true")
     parser.add_argument(
-        "--pull",
-        help="Download latest 'gentoo/stage3-amd64' docker image",
-        action="store_true")
-    parser.add_argument(
         "--storage-opt",
         help="Storage driver options for all volumes (same as Docker param)",
         nargs="+",
@@ -116,7 +112,11 @@ def parse_commandline(args):
     parser.add_argument(
         "--docker-image",
         help="Specify the docker image to use (default = %(default)s)",
-        default="gentoo/stage3-amd64")
+        default="gentoo/stage3")
+    parser.add_argument(
+        "--pull",
+        help="Download latest docker image",
+        action="store_true")
 
     options = parser.parse_args(args)
 

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -90,4 +90,4 @@ class TestParse(unittest.TestCase):
     def test_docker_image(self):
         options = ebuildtester.parse.parse_commandline(
             self.args + ["--manual"])
-        self.assertEqual(options.docker_image, "gentoo/stage3-amd64")
+        self.assertEqual(options.docker_image, "gentoo/stage3")


### PR DESCRIPTION
The old image, `gentoo/stage3-amd64`, is deprecated in favor of
`gentoo/stage3`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>