### PR TITLE
Remove additional Python environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9},bandit,pep8
+envlist = py3,bandit,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
It's easier to test locally if the default of the `envlist` is simply
Python3 and not a list of specific Python 3.x versions. A regular user
likely uses only one Python 3.x version. The other version are tested
in CI and we will still get test coverage this way.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>