### PR TITLE
Add option to specify the `docker` command

### DIFF
--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -44,7 +44,7 @@ class Docker:
         """
 
         options.log.info("%s %s" % (self.cid[:6], cmd))
-        docker_cmd = ["docker", "exec", "--interactive"]
+        docker_cmd = [options.options.docker_command, "exec", "--interactive"]
         docker_cmd += [self.cid, "/bin/bash"]
         docker = subprocess.Popen(docker_cmd,
                                   stdout=subprocess.PIPE,

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -1,4 +1,5 @@
 from ebuildtester.atom import Atom
+import os
 from pkg_resources import get_distribution
 import argparse
 import multiprocessing
@@ -112,6 +113,9 @@ def parse_commandline(args):
         help="Specify the docker image to use (default = %(default)s)",
         default="gentoo/stage3")
     parser.add_argument(
+        "--docker-command",
+        help="Specify the docker command")
+    parser.add_argument(
         "--pull",
         help="Download latest docker image",
         action="store_true")
@@ -138,5 +142,8 @@ def parse_commandline(args):
         options.update = True
     else:
         options.update = False
+
+    if not options.docker_command:
+        options.docker_command = os.getenv('DOCKER_COMMAND', default='docker')
 
     return options

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,9 +9,22 @@ description: |
 grade: stable
 confinement: strict
 
+environment:
+  DOCKER_COMMAND: docker-wrapper.sh
+
+plugs:
+  docker-executables:
+    interface: content
+    target: $SNAP/docker-snap
+    default-provider: docker
+
 apps:
   ebuildtester:
     command: bin/ebuildtester
+  confinement:
+    command: usr/bin/confinement.sh
+  docker:
+    command: usr/bin/docker-wrapper.sh
     plugs:
       - docker
 
@@ -23,3 +36,9 @@ parts:
     source-tag: v0.1.30
     requirements:
       - requirements.txt
+  docker-wrapper:
+    plugin: dump
+    source: .
+    organize:
+      confinement.sh: usr/bin/confinement.sh
+      docker-wrapper.sh: /usr/bin/docker-wrapper.sh


### PR DESCRIPTION
This is useful when running inside a snap where we do not have access to the
system `docker` command.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>