### PR TITLE
move log to /tmp/ebuildtester.log

### DIFF
--- a/ebuildtester/options.py
+++ b/ebuildtester/options.py
@@ -17,7 +17,7 @@ def init():
     log_ch.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
     log.addHandler(log_ch)
 
-    fh = logging.FileHandler("tester.log", "a")
+    fh = logging.FileHandler("/tmp/ebuildtester.log", "a")
     fh.setLevel(logging.INFO)
     fh.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
     log.addHandler(fh)


### PR DESCRIPTION
I don't know what you think about this. For my use case I prefer for logs to be automatically removed so I put it in tmp, but maybe there are other uses cases that require it to be stored in a permanent directory.