### PR TITLE
Add command line option to specify `FEATURES`

### DIFF
--- a/ebuildtester.bash-completion
+++ b/ebuildtester.bash-completion
@@ -1,5 +1,5 @@
 _ebuildtester() {
-    local cur prev opts
+    local cur prev opts prefix
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -27,22 +27,31 @@ _ebuildtester() {
       --with-X
       --with-vnc
       --profile
+      --features
       --docker-image
       --docker-command
       --pull
       --show-options
     )
 
-    if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
-        COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cur}) )
-        return 0
-    fi
-
     case "${prev}" in
         --portage-dir|--overlay-dir)
             COMPREPLY=( $(compgen -o dirnames -A directory ${cur}) )
             ;;
+        --features)
+            if [[ ${cur} =~ ^- ]]; then
+              prefix=("-P" "-")
+            else
+              prefix=()
+            fi
+            echo
+            COMPREPLY=( $(compgen ${prefix[@]} -W "ccache sandbox userfetch" -- ${cur#-}) )
+            ;;
     esac
 
+    if [[ ( ${cur} =~ ^-.* && ${prev} != --features ) || ${COMP_CWORD} -eq 1 ]] ; then
+        COMPREPLY=( $(compgen -W "${opts[*]}" -- ${cur}) )
+        return 0
+    fi
 }
 complete -F _ebuildtester ebuildtester

--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -202,15 +202,11 @@ class Docker:
 
         options.log.info("tweaking portage settings")
 
-        features = "-sandbox -usersandbox"
-
-        if options.options.binhost:
-            features += " getbinpkg"
-
         # Disable the usersandbox feature, it's not working well inside a
         # docker container.
-        self.execute("echo FEATURES=\\\"{}\\\" "
-                     ">> /etc/portage/make.conf".format(features))
+        self.execute(
+            f"echo FEATURES=\\\"{' '.join(options.options.features)}\\\" "
+            ">> /etc/portage/make.conf")
 
         self.execute(("echo MAKEOPTS=\\\"-j%d\\\" " %
                       (options.options.threads)) +

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -109,6 +109,13 @@ def parse_commandline(args):
         help="The profile to use (default = %(default)s)",
         default="default/linux/amd64/17.1")
     parser.add_argument(
+        '--features',
+        help="Set FEATURES, see https://wiki.gentoo.org/wiki/FEATURES "
+             "(default = %(default)s)",
+        default=["-sandbox", "-usersandbox", "userfetch"],
+        nargs="+",
+        action="append")
+    parser.add_argument(
         "--docker-image",
         help="Specify the docker image to use (default = %(default)s)",
         default="gentoo/stage3")
@@ -141,6 +148,17 @@ def parse_commandline(args):
         options.atom = temp
     else:
         options.atom = []
+
+    temp = []
+    for feature in options.features:
+        if type(feature) is list:
+            temp += feature
+        else:
+            temp.append(feature)
+    options.features = temp
+
+    if options.binhost:
+        options.features.append("getbinpkg")
 
     if options.with_vnc:
         options.atom += ["net-misc/tigervnc", "x11-wm/icewm"]


### PR DESCRIPTION
Since the FEATURES variable is an incremental variable the default values can be
changed by specifying new values, e.g.

    ebuildtester --features sandbox

would turn on the `sandbox` feature despite it being turned off by default.

Closes: nicolasbock/ebuildtester#119
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>