### PR TITLE
Remove non-zero exit on configure hook

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -8,5 +8,5 @@ if ! snapctl is-connected docker-executables; then
     echo "snap connect ebuildtester:docker-executables docker:docker-executables"
     echo
     echo "in order to use the ebuildtester command."
-    exit 1
+    # exit 1
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,31 +3,32 @@ base: core20
 adopt-info: ebuildtester
 summary: Tool to test a Gentoo ebuild and its dependencies
 description: |
-  This is a tool to test a Gentoo ebuild and its dependencies. The idea is that
-  the ebuild is emerged in a clean (and current) stage3 Docker container.
+  This is a tool to test a Gentoo ebuild and its dependencies. The idea is
+  that the ebuild is emerged in a clean (and current) stage3 Docker container.
 
-  Usage
-  -----
+  ## Installation
 
-  We are going to assume that the user has a local git clone of the portage tree in
+  This snap uses the `docker` snap and needs to be connected via
 
-  .. code-block:: bash
+     snap connect ebuildtester:docker-executables docker:docker-executables
+
+  ## Usage
+
+  We are going to assume that the user has a local git clone of the portage
+  tree in
 
      /usr/local/git/gentoo
 
   We have added a new ebuild and would like to verify that the build
   dependencies are all correct. We can build the package (ATOM) with:
 
-  .. code-block:: bash
-
      ebuildtester --portage-dir /usr/local/git/gentoo \
        --atom ATOM \
        --use USE1 USE2
 
-  where we have specified two USE flags, USE1 and USE2. The
-  `ebuildtester` command will now create a docker container and start
-  installing the ATOM. All specified dependencies will be installed as
-  well.
+  where we have specified two USE flags, USE1 and USE2. The `ebuildtester`
+  command will now create a docker container and start installing the ATOM.
+  All specified dependencies will be installed as well.
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
The hook will print out its message only if the exit code is non-zero.
However, this also prevents the snap from being installed.

This change moves the warning into the snap description.

Closes: nicolasbock/ebuildtester#193
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>