### PR TITLE
Rectify documentation about Docker storage driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,21 @@ Requirements
 ------------
 
 Using require `Docker <https://wiki.gentoo.org/wiki/Docker>`_ and `FUSE
-<https://wiki.gentoo.org/wiki/Filesystem_in_Userspace>`_. Docker must be
-configured to use the `devicemapper
-<https://docs.docker.com/storage/storagedriver/device-mapper-driver/>`_
-storage driver.  This can be achieved with the following inside
-``/etc/docker/daemon.json``:
+<https://wiki.gentoo.org/wiki/Filesystem_in_Userspace>`_.
+
+If you plan to use specific storage driver options (by passing
+``--storage-opt``), be aware that these are specific to the `configured Docker
+storage driver
+<https://docs.docker.com/storage/storagedriver/select-storage-driver/>`__. Refer
+to the Docker documentation about `storage drivers
+<https://docs.docker.com/storage/storagedriver/>`_ for more information.
+Particularly see the list of `options per storage driver
+<https://docs.docker.com/engine/reference/commandline/dockerd/#options-per-storage-driver>`_.
+
+System-wide configuration of the storage driver used by Docker is done in
+``/etc/docker/daemon.json``. For example, to select the `devicemapper
+<https://docs.docker.com/storage/storagedriver/device-mapper-driver/>`_ storage
+driver, specify:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
See the commit message for details.

Fixes #210.

This change duplicates documentation, which is already available from the Docker project. Users should basically be able to configure and handle their Docker setups without ebuildtester providing these instructions. A pointer to Docker documentation could be left in the README, but as ebuildtester by default no longer uses docker storage options, even this is not necessary anymore.

I’m fine if you shorten the requirements section to just the first paragraph left by this pull request in order to fix issue #210. (Of course I’m equally happy if you decide to merge this pull request in its current form. Future changes might be needed, when Docker changes.)