### PR TITLE
Move away from deprecated pkg_resources

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,13 +16,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: 3.7
-          - os: ubuntu-22.04
             python-version: 3.8
           - os: ubuntu-22.04
             python-version: 3.9
           - os: ubuntu-22.04
             python-version: '3.10'
+          - os: ubuntu-22.04
+            python-version: '3.11'
+          - os: ubuntu-22.04
+            python-version: '3.12'
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.os }} / ${{ matrix.python-version }} build
     steps:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 Developer Documentation
 =======================
 
-This project supports Python 3.7, 3.8, 3.9, and 3.10. Other Python versions
+This project supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. Other Python versions
 might work as well but are not regularly tested.
 
 For locally testing changes it is very handy to install `tox` which automates

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -3,7 +3,7 @@
 import os
 import argparse
 import multiprocessing
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 from ebuildtester.atom import Atom
 
@@ -17,7 +17,7 @@ def parse_commandline(args):
     parser.add_argument(
         "--version",
         action="version",
-        version="v" + get_distribution("ebuildtester").version)
+        version="v" + version("ebuildtester"))
     parser.add_argument(
         "--atom",
         help="The package atom(s) to install",


### PR DESCRIPTION
* Use importlib.metadata which has been included in the python standard library since 3.8.