### PR TITLE
Use new path for workflow status.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ the ebuild is emerged in a clean (and current) stage3 Docker container.
    :target: http://ebuildtester.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://github.com/nicolasbock/ebuildtester/workflows/build/badge.svg
+.. image:: https://github.com/nicolasbock/ebuildtester/actions/workflows/build.yaml/badge.svg
    :target: https://github.com/nicolasbock/ebuildtester/actions?query=workflow%3Abuild
    :alt: GitHub Actions
 


### PR DESCRIPTION
* An alternative path was added sometime in 2021 and it appears like the old path was removed without a word.

https://github.com/github/docs/commit/f9b50ac4387b46f8a3ca80ede226fb15384ff7f3