### PR TITLE
Fix key errors when binhosts are enabled

### DIFF
--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -223,8 +223,11 @@ class Docker:
                       (options.OPTIONS.threads)) +
                      ">> /etc/portage/make.conf")
         if options.OPTIONS.binhost:
-            self.execute("echo PORTAGE_BINHOST=\\\"{}\\\""
-                         ">> /etc/portage/make.conf"
+            self.execute("getuto")
+            self.execute("echo -e '[ebuildtester]\n"
+                         "priority = 999\n"
+                         "sync-uri = {}\n'"
+                         ">> /etc/portage/binrepos.conf/ebuildtester.conf"
                          .format(options.OPTIONS.binhost))
         if options.OPTIONS.unstable:
             self.execute("echo ACCEPT_KEYWORDS=\\\"~amd64\\\" " +


### PR DESCRIPTION
Closes: #215

Ideally we should be able to enable just the official overlay and/or add multiple binhosts in a configurable manner (see #223). In the short term at least this PR will fix the issue until we have a better mechanism to handle binhsots.  