### PR TITLE
fix support for multiple atoms

### DIFF
--- a/ebuildtester/main.py
+++ b/ebuildtester/main.py
@@ -42,13 +42,15 @@ def main():
             "--autounmask-license=y ",
             "--autounmask-continue=y "]
 
-        atom = Atom(" ".join(map(str, options.OPTIONS.atom)))
+        atoms = [Atom(str(a)) for a in options.OPTIONS.atom]
 
         if options.OPTIONS.binhost:
-            p = "{}/{}".format(atom.category, atom.package)
-            emerge_command.append("--usepkg-exclude={}".format(p))
+            for a in atoms:
+                p = "{}/{}".format(a.category, a.package)
+                emerge_command.append("--usepkg-exclude={}".format(p))
 
-        emerge_command.append(str(atom))
+        for a in atoms:
+            emerge_command.append(str(a))
         container.execute(" ".join(["echo"] + emerge_command + ["--ask"]) +
                           " >> ~/.bash_history")
 


### PR DESCRIPTION
Previously only the first atom passed was emerged.

A string of the form "=cat/package2 =cat2/package2" was passed to Atom constructor at line 45. This class made a `split("=")` and from that only took the last result of the list (`self.atom = temp[-1`] which resulted in ignoring all previous atoms.

Instead of making Atom class to support multiple atoms, I changed the main so it creates N Atom classes, one for each atom passed. 