### PR TITLE
add configuration file support

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           sudo apt install python3-pip
           pip list --verbose
+          pip install -r requirements.txt
           python3 setup.py install
 
       - name: Clone portage

--- a/README.rst
+++ b/README.rst
@@ -135,3 +135,21 @@ The command understands the following command line arguments:
      --show-options        Show currently selected options and defaults
      --ccache CCACHE_DIR   Path to mount that contains ccache cache
      --batch               Do not drop into interactive shell
+
+It is also possible to store default values in a toml configuration file at `~/.config/ebuildtester/config.toml`.
+The next example shows all the configuration options that are currently available:
+
+.. code-block:: toml
+
+    portage_dir = "/var/db/repos/gentoo"
+    overlay_dir = ["/var/db/repos/guru"]
+
+    features = ["sandbox", "usersandbox", "userfetch"]
+
+    install_basic_packages = false
+    docker_command = "docker"
+    unstable = true
+    update = true
+    batch = false
+    pull = true
+    rm = true

--- a/ebuildtester/config.py
+++ b/ebuildtester/config.py
@@ -1,0 +1,41 @@
+import tomli
+from appdirs import user_config_dir
+
+
+class ConfigFile:
+    def __init__(self):
+        appname = "ebuildtester"
+        cfg_dir = user_config_dir(appname)
+        cfg_file = "{}/config.toml".format(cfg_dir)
+
+        self._d = {}
+        self._cfg = None
+        try:
+            with open(cfg_file, mode="rb") as fp:
+                self._cfg = tomli.load(fp)
+        except FileNotFoundError:
+            pass
+
+    def _add(self, e, t=None):
+        if e in self._cfg:
+            if t and type(self._cfg[e]) is not t:
+                raise Exception("{} is not of type {}".format(e, t))
+            self._d[e] = self._cfg[e]
+
+    def get_cfg(self):
+        if self._cfg is None:
+            return {}
+
+        self._add("batch")
+        self._add("docker_command")
+        self._add("features", list)
+        self._add("install_basic_packages")
+        self._add("manual")
+        self._add("overlay_dir", list)
+        self._add("portage_dir")
+        self._add("pull")
+        self._add("rm")
+        self._add("unstable")
+        self._add("update")
+
+        return self._d

--- a/ebuildtester/main.py
+++ b/ebuildtester/main.py
@@ -4,6 +4,7 @@ import os.path
 import sys
 
 from ebuildtester.atom import Atom
+from ebuildtester.config import ConfigFile
 from ebuildtester.docker import Docker, ExecuteFailure
 from ebuildtester.parse import parse_commandline
 import ebuildtester.options as options
@@ -12,7 +13,8 @@ import ebuildtester.options as options
 def main():
     """The main function."""
 
-    options.OPTIONS = parse_commandline(sys.argv[1:])
+    cfg = ConfigFile()
+    options.OPTIONS = parse_commandline(sys.argv[1:], cfg.get_cfg())
     if len(options.OPTIONS.atom) > 0:
         options.set_logfile('ebuildtester-'
                             + ':'.join([f'{atom.category}-{atom.package}'

--- a/ebuildtester/parse.py
+++ b/ebuildtester/parse.py
@@ -8,7 +8,7 @@ from importlib.metadata import version
 from ebuildtester.atom import Atom
 
 
-def parse_commandline(args):
+def parse_commandline(args, d):
     """Parse the command line."""
 
     parser = argparse.ArgumentParser(
@@ -38,7 +38,7 @@ def parse_commandline(args):
     parser.add_argument(
         "--portage-dir",
         help="The local portage directory",
-        required=True)
+        required="portage_dir" not in d)
     parser.add_argument(
         "--overlay-dir",
         help="Add overlay dir (can be used multiple times)",
@@ -145,6 +145,7 @@ def parse_commandline(args):
         '--debug',
         help='Add some debugging output',
         action='store_true')
+    parser.set_defaults(**d)
 
     if '--complete' in args:
         print('Suggesting')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tomli
+appdirs

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -10,77 +10,80 @@ class TestParse(unittest.TestCase):
 
     def test_atom(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--atom", "=SECTION/ATOM-1.0.0"])
+            self.args + ["--atom", "=SECTION/ATOM-1.0.0"], {})
         self.assertTrue(Atom("=SECTION/ATOM-1.0.0") in options.atom)
 
     def test_binhost(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--binhost", "http://localhost:8080"])
+            self.args + ["--manual", "--binhost", "http://localhost:8080"], {})
         self.assertIn("http://localhost:8080", options.binhost)
 
     def test_live_ebuild(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--live-ebuild"])
+            self.args + ["--manual", "--live-ebuild"], {})
         self.assertTrue(options.live_ebuild)
 
     def test_manual(self):
-        options = ebuildtester.parse.parse_commandline(self.args + ["--manual"])
+        options = ebuildtester.parse.parse_commandline(self.args + ["--manual"], {})
         self.assertTrue(options.manual)
 
     def test_portage_dir(self):
         import sys
         if sys.version_info[0] == 2 and sys.version_info[1] == 6:
-            self.assertRaises(Exception, ebuildtester.parse.parse_commandline())
+            self.assertRaises(Exception, ebuildtester.parse.parse_commandline({}))
         else:
             with self.assertRaises(Exception):
-                options = ebuildtester.parse.parse_commandline()
+                options = ebuildtester.parse.parse_commandline({})
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual"])
+            self.args + ["--manual"], {})
         self.assertEqual("~/gentoo", options.portage_dir)
 
     def test_overlay_dir(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--overlay-dir", "."])
+            self.args + ["--manual", "--overlay-dir", "."], {})
         self.assertTrue("." in options.overlay_dir)
+        options = ebuildtester.parse.parse_commandline(
+            self.args + ["--manual", "--overlay-dir", "."], {"overlay_dir": ["/overlay/path"]})
+        self.assertTrue("/overlay/path" in options.overlay_dir)
 
     def test_update(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--update"])
+            self.args + ["--manual", "--update"], {})
         self.assertFalse(options.update)
 
     def test_threads(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--threads", "4"])
+            self.args + ["--manual", "--threads", "4"], {})
         self.assertEqual(options.threads, 4)
 
     def test_use(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--use", "a", "b", "c"])
+            self.args + ["--manual", "--use", "a", "b", "c"], {})
         self.assertTrue("a" in options.use)
         self.assertTrue("b" in options.use)
         self.assertTrue("c" in options.use)
 
     def test_unmask(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--unmask", "ATOM"])
+            self.args + ["--manual", "--unmask", "ATOM"], {})
         self.assertTrue("ATOM" in options.unmask)
 
     def test_gcc_version(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--gcc-version", "VER"])
+            self.args + ["--manual", "--gcc-version", "VER"], {})
         self.assertEqual("VER", options.gcc_version)
 
     def test_python_single_target(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--python-single-target", "-* python3_8"])
+            self.args + ["--manual", "--python-single-target", "-* python3_8"], {})
         self.assertEqual("-* python3_8", options.python_single_target)
 
     def test_python_targets(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual", "--python-targets", "python3_8"])
+            self.args + ["--manual", "--python-targets", "python3_8"], {})
         self.assertEqual("python3_8", options.python_targets)
 
     def test_docker_image(self):
         options = ebuildtester.parse.parse_commandline(
-            self.args + ["--manual"])
+            self.args + ["--manual"], {})
         self.assertEqual(options.docker_image, "gentoo/stage3")


### PR DESCRIPTION
I think it's more clean to have some values in a configuration file than having to pass it as command line arguments or creating an alias. This only adds two dependencies, tomli and appdirs which I believe are very common.

In the future I would like to add ccache and binhost to the config file and change the command line arguments forcefully disable them, instead of having to pass the directory or URL at command line, but I am still not so sure, so for now I just added the most common things.