### PR TITLE
fix podman error when binding a volume from an unexisting directory

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -44,14 +44,12 @@ jobs:
           ebuildtester --portage-dir ~/gentoo \
             --rm \
             --pull \
-            --ccache /var/tmp/ccache \
             --atom app-editors/nano
           ebuildtester --portage-dir ~/gentoo \
             --docker-command podman \
             --docker-image docker.io/gentoo/stage3 \
             --rm \
             --pull \
-            --ccache /var/tmp/ccache \
             --atom app-editors/nano
 
       - name: Test whether any container is still running

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -46,6 +46,13 @@ jobs:
             --pull \
             --ccache /var/tmp/ccache \
             --atom app-editors/nano
+          ebuildtester --portage-dir ~/gentoo \
+            --docker-command podman \
+            --docker-image docker.io/gentoo/stage3 \
+            --rm \
+            --pull \
+            --ccache /var/tmp/ccache \
+            --atom app-editors/nano
 
       - name: Test whether any container is still running
         run: docker ps --all

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -42,12 +42,14 @@ jobs:
       - name: Testbuild of `nano`
         run: |
           ebuildtester --portage-dir ~/gentoo \
+            --batch \
             --rm \
             --pull \
             --atom app-editors/nano
           ebuildtester --portage-dir ~/gentoo \
             --docker-command podman \
             --docker-image docker.io/gentoo/stage3 \
+            --batch \
             --rm \
             --pull \
             --atom app-editors/nano

--- a/ebuildtester/docker.py
+++ b/ebuildtester/docker.py
@@ -151,6 +151,12 @@ class Docker:
     def _create_container(self, docker_image, local_portage, overlays):
         """Create new container."""
 
+        distdir = "{}/distfiles".format(local_portage)
+        os.makedirs(distdir, exist_ok=True)
+
+        pkgdir = "{}/packages".format(local_portage)
+        os.makedirs(pkgdir, exist_ok=True)
+
         docker_args = options.OPTIONS.docker_command \
             + ["create",
                "--tty",
@@ -162,8 +168,8 @@ class Docker:
                "--device", "/dev/fuse",
                "--workdir", "/root",
                "--volume", "%s:/var/db/repos/gentoo" % local_portage,
-               "--volume", "%s/distfiles:/var/cache/distfiles" % local_portage,
-               "--volume", "%s/packages:/var/cache/binpkgs" % local_portage]
+               "--volume", "%s:/var/cache/distfiles" % distdir,
+               "--volume", "%s:/var/cache/binpkgs" % pkgdir]
 
         if options.OPTIONS.storage_opt:
             for s in options.OPTIONS.storage_opt:


### PR DESCRIPTION
Add podman to the functional tests

Issue: #120

We should create the dsitfiles and pkgdir to a ~/.local/share directory and create options to allow the users to select a different directories. 

Alternatively, it can be overengineered to detect if the container will have permissions to write to system-wide directories. If not but the user executing ebuildtester have permissions (because it's in portage group for example) then we could use the same UID inside the container or a similar approach. 