### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasbock/ebuildtester/security/code-scanning/4](https://github.com/nicolasbock/ebuildtester/security/code-scanning/4)

To fix the flagged issue, add a `permissions` block to the workflow to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow primarily checks out code, builds, tests, and archives artifacts, the least privilege permissions required are likely `contents: read` (for reading the repository contents) and possibly `write` permissions for `actions` if artifact uploads are required.

The permissions block can be added globally at the workflow level, so it applies to all jobs. Alternatively, it can be added to specific jobs if different permissions are required for each job. In this case, we will add the permissions block globally for simplicity and clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
