### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,5 +1,6 @@
 name: Functional testing
-
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasbock/ebuildtester/security/code-scanning/2](https://github.com/nicolasbock/ebuildtester/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the root of the workflow to restrict the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow's operations. Based on the workflow steps, the `contents: read` permission is sufficient, as it allows the workflow to read repository contents without enabling write access. Additional permissions should only be added if explicitly required by the workflow.

The `permissions` block should be added after the `name` field at the top of the workflow file to apply the permissions globally to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
