### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasbock/ebuildtester/security/code-scanning/1](https://github.com/nicolasbock/ebuildtester/security/code-scanning/1)

To address the issue, add a `permissions` block to the root of the workflow file. This block will apply to all jobs unless overridden individually. The permissions should only include `contents: read`, as this workflow appears to focus on building and verifying a package and does not need write access. This change will ensure that the `GITHUB_TOKEN` used by the workflow has limited access to the repository, reducing the risk of unintended privilege escalation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
