### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Publish PyPI Package
+    permissions:
+      contents: read
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
@@ -44,6 +46,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/ebuildtester
     permissions:
+      contents: read
       id-token: write # IMPORTANT: mandatory for trusted publishing
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasbock/ebuildtester/security/code-scanning/5](https://github.com/nicolasbock/ebuildtester/security/code-scanning/5)

To fix the issue, the workflow should include a `permissions` block specifying the least privileges required for each job. This can be done at the root level of the workflow (applicable to all jobs) or for individual jobs. In this case:
- For the `build` job, the permissions should be restricted to `contents: read` because it only interacts with code repositories and uploads artifacts.
- For the `publish-to-pypi` job, the permissions already specify the required `id-token: write` scope, but we can clarify other permissions explicitly (like `contents: read`).

Changes will be made to `.github/workflows/publish.yaml` to introduce these explicit permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
